### PR TITLE
Fix Typographical Errors in SHA384.sol and RegistrationSimple.test.ts

### DIFF
--- a/contracts/utils/SHA384.sol
+++ b/contracts/utils/SHA384.sol
@@ -318,7 +318,7 @@ library LibBytes {
                     let first := mload(source)
 
                     // Copy whole words back to front
-                    // We use a signed comparisson here to allow dEnd to become
+                    // We use a signed comparison here to allow dEnd to become
                     // negative (happens when source and dest < 32). Valid
                     // addresses in local memory will never be larger than
                     // 2**255, so they can be safely re-interpreted as signed.

--- a/test/registration/RegistrationSimple.test.ts
+++ b/test/registration/RegistrationSimple.test.ts
@@ -249,7 +249,7 @@ describe("RegistrationSimple", () => {
       );
     });
 
-    it("should revert if non-exising operation ID was provided", async () => {
+    it("should revert if non-existing operation ID was provided", async () => {
       const encoder = new ethers.AbiCoder();
       const data = encoder.encode(["address[]", "uint8[]"], [[FIRST.address], [12 as RegistrationSimpleOperationId]]);
 


### PR DESCRIPTION


**Description:**

This pull request addresses minor typographical errors in two files:

1. **contracts/utils/SHA384.sol**:
   - Corrected the spelling of "comparison" in a comment.

2. **test/registration/RegistrationSimple.test.ts**:
   - Fixed the spelling of "non-existing" in a test description.

These changes improve code readability and maintain consistency in documentation.
