### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup
         uses: ./.github/actions/setup


### PR DESCRIPTION
Node 20 compatibility: switch all jobs to actions/checkout@v4. Pure maintenance, behavior unchanged.