### PR TITLE
docs: fix typos in smart contract comments

### DIFF
--- a/contracts/interfaces/rollup/IMessageService.sol
+++ b/contracts/interfaces/rollup/IMessageService.sol
@@ -11,7 +11,7 @@ interface IMessageService {
      * @notice Emitted when a message is sent.
      * @param _from The indexed sender address of the message (msg.sender).
      * @param _to The indexed intended recipient address of the message on the other layer.
-     * @param _fee The fee being being paid to deliver the message to the recipient in Wei.
+     * @param _fee The fee being paid to deliver the message to the recipient in Wei.
      * @param _value The value being sent to the recipient in Wei.
      * @param _nonce The unique message number.
      * @param _calldata The calldata being passed to the intended recipient when being called on claiming.

--- a/contracts/state/PoseidonSMT.sol
+++ b/contracts/state/PoseidonSMT.sol
@@ -110,7 +110,7 @@ contract PoseidonSMT is Initializable, UUPSUpgradeable {
     }
 
     /**
-     * @notice Check if the SMT root is valid. Zero root in always invalid and latest root is always a valid one.
+     * @notice Check if the SMT root is valid. Zero root is always invalid and latest root is always a valid one.
      */
     function isRootValid(bytes32 root_) external view virtual returns (bool) {
         if (root_ == bytes32(0)) {


### PR DESCRIPTION
- IMessageService: removed duplicated word in `_fee` param description.
- PoseidonSMT: corrected grammar in root validity notice (`in` → `is`).